### PR TITLE
Dependency keen

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,4 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
 encoding//src/main/resources=UTF-8
-encoding//src/test/java=UTF-8
 encoding/<project>=UTF-8

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 			<dependency>
 				<groupId>io.keen</groupId>
 				<artifactId>keen-client-api-java</artifactId>
-				<version>2.1.0</version>
+				<version>2.1.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 			<dependency>
 				<groupId>io.keen</groupId>
 				<artifactId>keen-client-api-java</artifactId>
-				<version>2.0.3</version>
+				<version>2.1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jsoup</groupId>

--- a/src/main/java/io/devyse/scheduler/analytics/keen/KeenEngine.java
+++ b/src/main/java/io/devyse/scheduler/analytics/keen/KeenEngine.java
@@ -272,11 +272,11 @@ public class KeenEngine {
 	protected void initialize(String config, long timeout){
 		try{
 			//enable logging to better track issues during Keen setup
+			//but disable the default JUL log handler installed by Keen
+			//since this project uses SLF4j with Logback
+			KeenLogging.disableDefaultLogHandler();
 			KeenLogging.enableLogging();
-			
-			//disable the default JUL log handler installed by Keen
-			KeenUtils.disableKeenDefaultLogHandler();
-			
+						
 			configureKeenClient(config);
 			configureShutdownHook(timeout);
 			configureGlobalProperties();

--- a/src/main/java/io/devyse/scheduler/analytics/keen/KeenUtils.java
+++ b/src/main/java/io/devyse/scheduler/analytics/keen/KeenUtils.java
@@ -24,15 +24,10 @@
 package io.devyse.scheduler.analytics.keen;
 
 import io.devyse.scheduler.security.Privacy;
-import io.keen.client.java.KeenLogging;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import org.slf4j.ext.XLogger;
-import org.slf4j.ext.XLoggerFactory;
 
 /**
  * Keen utility methods for building events and mapping data to events
@@ -42,11 +37,6 @@ import org.slf4j.ext.XLoggerFactory;
  */
 class KeenUtils {
 	
-	/**
-	 * Static logger
-	 */
-	private static final XLogger logger = XLoggerFactory.getXLogger(KeenUtils.class);
-
 	/**
 	 * Keen IO internally uses JSON to represent events. The Keen IO Java API requires that a
 	 * nested map, essentially identical in structure to a JSON document, is sent as an event.
@@ -172,31 +162,6 @@ class KeenUtils {
 			map.put(key, Privacy.redactPrivateInformation(value.toString()));
 		}else{
 			map.put(key, value);
-		}
-	}
-	
-	/**
-	 * The method unregisters Keen's default JUL log handler to allow the application to have more control over
-	 * how the KeenClient logs.
-	 * 
-	 * @since 4.12.6
-	 */
-	protected static void disableKeenDefaultLogHandler(){
-		try{
-			Class<KeenLogging> clazz = KeenLogging.class;
-			Field loggerField = clazz.getDeclaredField("LOGGER");
-			Field handlerField = clazz.getDeclaredField("HANDLER");
-			
-			loggerField.setAccessible(true);
-			handlerField.setAccessible(true);
-			
-			java.util.logging.Logger keenLogger = (java.util.logging.Logger)loggerField.get(null);
-			java.util.logging.Handler keenHandler = (java.util.logging.Handler)handlerField.get(null);
-			
-			keenLogger.removeHandler(keenHandler);
-			logger.debug("Removed KeenClient default JUL log handler {} from KeenLogging logger {}", keenHandler, keenLogger);
-		}catch(Exception e){
-			logger.error("Unable to remove KeenClient default JUL log handler from KeenLogging logger", e);
 		}
 	}
 }


### PR DESCRIPTION
Upgraded Keen IO SDK to 2.1.1 and utilized new mechanism to disable default JUL log handler installed by Keen instead of custom reflection mechanism.