### PR TITLE
Issue 32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.devyse.scheduler-legacy</groupId>
 	<artifactId>scheduler-legacy</artifactId>
-	<version>4.12.8</version>
+	<version>4.12.9-SNAPSHOT</version>
 	<name>Kettering Course Scheduler</name>
 	<url>http://coursescheduler.io</url>
 	<description>Kettering Course Scheduler is an operating system independent schedule designer for Kettering University. Courses are selected from a list of available courses based on the registration term and possible schedules are generated.</description>

--- a/src/main/java/Scheduler/OptionsFrame.java
+++ b/src/main/java/Scheduler/OptionsFrame.java
@@ -61,6 +61,8 @@ import javax.swing.JOptionPane;					//used for pop-up error messages
 import javax.swing.text.NumberFormatter;		//used for number filtering
 
 import java.text.DecimalFormat;					//used for number filtering
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;						//used to parse strings
@@ -119,7 +121,8 @@ public class OptionsFrame extends JFrame {
 	protected JTextField newCampus;			//to input new on campus course download url
 	protected JTextField newDist;			//to input new distance course download url
 	protected JCheckBox analyticsOptOut;	//to option out of the analytics reporting
-	
+	protected JLabel connectionTimeoutLabel;//label for the connection timeout text field 
+	protected JTextField connectionTimeout; //for configuration of the socket connection timeout
 	
 	/*********************************************************
 	 * The following are the protected fields for the button portion
@@ -250,6 +253,13 @@ public class OptionsFrame extends JFrame {
 		analyticsOptOut.addActionListener(chkBox);
 		analyticsOptOut.setMnemonic('a');
 		analyticsOptOut.setToolTipText("Do not perform anonymous data collection");
+
+		connectionTimeout = new JFormattedTextField(NumberFormat.getIntegerInstance()); 
+		connectionTimeout.setToolTipText("The amount of time in milliseconds the network socket should be allowed to stay open while waiting for a connection or read response.");
+		connectionTimeout.setVisible(true);
+		connectionTimeoutLabel = new JLabel("Socket connection timeout (ms) for slow servers");
+		connectionTimeoutLabel.setDisplayedMnemonic('S');
+		connectionTimeoutLabel.setLabelFor(connectionTimeout);
 		
 		newURL = new JTextField(20);			//create the text field with min size
 		newSID = new JTextField(20);			//create the text field with min size
@@ -307,6 +317,13 @@ public class OptionsFrame extends JFrame {
 			)
 			.addGroup(generalTabLayout.createSequentialGroup()
 				.addGap(2 * horizSpace)
+				.addComponent(connectionTimeoutLabel)
+				.addGap(horizSpace)
+				.addComponent(connectionTimeout)
+				.addGap(2 * horizSpace)
+			)
+			.addGroup(generalTabLayout.createSequentialGroup()
+				.addGap(2 * horizSpace)
 				.addComponent(analyticsOptOut)
 				.addGap(2*horizSpace)
 			)
@@ -346,6 +363,12 @@ public class OptionsFrame extends JFrame {
 			.addGroup(generalTabLayout.createParallelGroup()//add a row of items
 				.addComponent(overrideURL)//add the override url check box
 				.addComponent(newURL)//add the url input field
+			)
+			.addGap(horizSpace)
+			.addGroup(generalTabLayout.createParallelGroup()
+				.addComponent(connectionTimeoutLabel)
+				.addComponent(connectionTimeout)
+					
 			)
 			.addGap(2 * horizSpace)
 			.addComponent(analyticsOptOut)
@@ -434,6 +457,8 @@ public class OptionsFrame extends JFrame {
 		overrideSID.setSelected(prefs.isOverRideSID());//set the checkbox value
 		newSID.setText(prefs.getSID());			//set the sid text
 		newSID.setEnabled(prefs.isOverRideSID());//set if the sid field is enabled
+		
+		connectionTimeout.setText(NumberFormat.getIntegerInstance().format(prefs.getConnectionTimeout()));
 		
 		enableCampusGrad.setSelected(prefs.isDownloadGrad());//set if on campus grad courses are downloaded
 		enableDistGrad.setSelected(prefs.isDownloadGradDist());//set if off campus grad courses are downloaded
@@ -809,6 +834,7 @@ public class OptionsFrame extends JFrame {
 		public void actionPerformed(ActionEvent event){
 			Object source = event.getSource();	//get the source of teh event
 			boolean updateRMP = false;	//boolean for downloading rmp
+			Number timeout;
 			
 			if(source.equals(apply)){			//check if the source is the apply button
 				Preferences prefs = Main.prefs;	//get the main form preferences
@@ -817,6 +843,13 @@ public class OptionsFrame extends JFrame {
 				double max = 0;					//create and initialize a double for the max gap
 				boolean cont = true;			//create and initialise a boolean for error checking
 				Period preferred = new Period();//create a new preferred period
+				
+				
+				try {
+					timeout = NumberFormat.getIntegerInstance().parse(connectionTimeout.getText());
+				} catch (ParseException e) {
+					timeout = 45000;
+				}
 				
 				if (enableRatings.isSelected()){
 					try{							//try to catch exceptions
@@ -936,6 +969,8 @@ public class OptionsFrame extends JFrame {
 					prefs.setDownloadUGrad(enableUGrad.isSelected());//set the download undergrad
 					prefs.setOverRideURL(overrideURL.isSelected());//set the url override
 					prefs.setURL(newURL.getText());	//set the url override value
+					
+					prefs.setConnectionTimeout(timeout.intValue());
 					
 					prefs.setOverRideSID(overrideSID.isSelected());//set the sid override
 					prefs.setSID(newSID.getText());	//set the sid override value

--- a/src/main/java/Scheduler/Parser.java
+++ b/src/main/java/Scheduler/Parser.java
@@ -163,7 +163,7 @@ public enum Parser {
 			TermSelector selector = new StaticSelector(term);
 			sync.updateWatch("Checking available terms in Banner", sync.finished++);
 			logger.info("Checking available terms in Banner");
-			TermSelectionParser termSelect = new TermSelectionParser(Jsoup.connect(url).method(Method.GET).execute().parse(), timeout, selector);
+			TermSelectionParser termSelect = new TermSelectionParser(Jsoup.connect(url).method(Method.GET).timeout(timeout).execute().parse(), timeout, selector);
 
 			if(sync.isCanceled()){
 				logger.info("Download cancelled. Shutting down executor pool");

--- a/src/main/java/Scheduler/Parser.java
+++ b/src/main/java/Scheduler/Parser.java
@@ -57,6 +57,7 @@ import java.util.Scanner;						//import scanner
 import java.util.concurrent.ForkJoinPool;
 
 import javax.swing.JOptionPane;					//Import message pane
+import javax.swing.SwingUtilities;
 
 import org.jsoup.Jsoup;
 import org.jsoup.Connection.Method;
@@ -215,8 +216,21 @@ public enum Parser {
 			sync.updateWatch("Finished processing courses from Banner", sync.finished++);
 			logger.info("Finished processing courses from Baner");
 			return items;
-		} catch (Exception e) {
+		} catch (final Exception e) {
+			sync.updateWatch("Error retrieving or parsing course dataset from Banner",sync.finished);
 			logger.error("Error retrieving or parsing course dataset from Banner", e);
+			
+			SwingUtilities.invokeLater(new Runnable(){
+				public void  run(){
+					JOptionPane.showMessageDialog(
+						Main.master, 
+						"Please file an issue on GitHub and attach the logs from "+ Main.folderName + ".\n"+e.getMessage(),
+						"Error retrieving or parsing course dataset from Banner",
+						JOptionPane.ERROR_MESSAGE
+					);
+				}
+			});
+			
 			return null;
 		}
 	}

--- a/src/main/java/Scheduler/Parser.java
+++ b/src/main/java/Scheduler/Parser.java
@@ -127,6 +127,7 @@ public enum Parser {
 	private static Database parseKUCourses(String term, String url, ThreadSynch sync)
 			throws IOException{
 		boolean downloadRatings = Main.prefs.isRateMyProfessorEnabled() && Main.prefs.isRatingsEnabled();
+		int timeout = Main.prefs.getConnectionTimeout();
 		Database items = new Database(downloadRatings);//create new database
 				
 		if (downloadRatings){		//check if using rate my professor ratings
@@ -139,7 +140,7 @@ public enum Parser {
 		}
 		
 		long start = System.currentTimeMillis();
-		jsoupParse(items, sync, url, term);
+		jsoupParse(items, sync, url, term, timeout);
 		long end = System.currentTimeMillis();		
 		
 		if(sync.isCanceled()){
@@ -155,9 +156,8 @@ public enum Parser {
 		return items;									//return database
 	}
 	
-	private static Database jsoupParse(Database items, ThreadSynch sync, String url, String term){
-		ForkJoinPool pool = new ForkJoinPool();
-		int timeout = 60000;  //TODO retrieve from config	
+	private static Database jsoupParse(Database items, ThreadSynch sync, String url, String term, int timeout){
+		ForkJoinPool pool = new ForkJoinPool();	
 		
 		try {
 			TermSelector selector = new StaticSelector(term);

--- a/src/main/java/Scheduler/Preferences.java
+++ b/src/main/java/Scheduler/Preferences.java
@@ -45,6 +45,10 @@ import java.util.UUID;
  * 
  * @see Serializable
 ********************************************************/
+/**
+ * @author mreinhold
+ *
+ */
 public class Preferences implements Serializable {
 	
 	
@@ -92,6 +96,9 @@ public class Preferences implements Serializable {
 	private boolean analyticsOptOut;			//opt out flag for analytics
 	
 	private int policyVersion;					//policy version accepted
+	
+	private int connectionTimeout = 45000;		//socket connection timeout, default is 45000
+
 
 	/*********************************************************
 	 * (Constructor)
@@ -711,5 +718,19 @@ public class Preferences implements Serializable {
 	 */
 	public void setPolicyVersion(int policyVersion) {
 		this.policyVersion = policyVersion;
+	}
+
+	/**
+	 * @return the connection timeout
+	 */
+	public int getConnectionTimeout() {
+		return connectionTimeout;
+	}
+
+	/**
+	 * @param connectionTimeout the connection timeout to set
+	 */
+	public void setConnectionTimeout(int connectionTimeout) {
+		this.connectionTimeout = connectionTimeout;
 	}
 }

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/AbstractParser.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/AbstractParser.java
@@ -136,7 +136,7 @@ public abstract class AbstractParser<V> extends ForkJoinTask<V> {
 			return true;
 		} catch (Exception e) {
 			logger.error("Unable to parse the source document: {}", source, e);
-			return false;
+			throw new RuntimeException(e);
 		}
 	}
 	

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/AbstractParser.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/AbstractParser.java
@@ -62,14 +62,22 @@ public abstract class AbstractParser<V> extends ForkJoinTask<V> {
 	private V result;
 
 	/**
+	 * The connection timeout which should be used for any connections
+	 * created or consumed by this AbstractParser
+	 */
+	private int timeout;
+	
+	/**
 	 * Create a new AbstractParser to parse the specified document.
 	 * 
 	 * @param document the document which will be parsed by the AbstractParser
+	 * @param timeout the connection timeout
 	 */
-	public AbstractParser(Document document){
+	public AbstractParser(Document document, int timeout){
 		super();
 		
 		this.setSource(document);
+		this.setTimeout(timeout);
 	}
 	
 	/* (non-Javadoc)
@@ -100,6 +108,22 @@ public abstract class AbstractParser<V> extends ForkJoinTask<V> {
 	 */
 	private void setSource(Document source) {
 		this.source = source;
+	}
+	
+	/**
+	 * Change the socket connection timeout for the form submission
+	 * 
+	 * @param timeout the desired socket timeout for the connection to the form target
+	 */
+	protected void setTimeout(int timeout){
+		this.timeout = timeout;
+	}
+	
+	/**
+	 * @return the current connection timeout in milliseconds
+	 */
+	protected int getTimeout(){
+		return this.timeout;
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/FormParser.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/FormParser.java
@@ -67,9 +67,10 @@ public abstract class FormParser extends AbstractParser<Document> {
 	 * form fields and response parameters.
 	 * 
 	 * @param document the document which contains the form that will be parsed
+	 * @param timeout the connection timeout in milliseconds which will be applied to the target of the form submission
 	 */
-	public FormParser(Document document) {
-		super(document);
+	public FormParser(Document document, int timeout) {
+		super(document, timeout);
 	}
 	
 	/* (non-Javadoc)
@@ -98,6 +99,7 @@ public abstract class FormParser extends AbstractParser<Document> {
 		
 		//prepare a connection from the form
 		Connection connection = prepareForm(form);
+		connection.timeout(this.getTimeout());
 		
 		//build the form parameters
 		Collection<KeyVal> data = buildFormParameters(form, connection);

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/JsoupParserTest.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/JsoupParserTest.java
@@ -55,12 +55,14 @@ public class JsoupParserTest {
 		ForkJoinPool pool = new ForkJoinPool();
 		Database latest = new Database(true);
 		
+		int timeout = 10000;
+		
 		try {
 			TermSelector selector = new StaticSelector("201501");
-			TermSelectionParser termSelect = new TermSelectionParser(Jsoup.connect(startURL).method(Method.GET).execute().parse(), selector);
-			CourseSelectionParser courseSelect = new CourseSelectionParser(pool.invoke(termSelect));
+			TermSelectionParser termSelect = new TermSelectionParser(Jsoup.connect(startURL).method(Method.GET).execute().parse(), timeout, selector);
+			CourseSelectionParser courseSelect = new CourseSelectionParser(pool.invoke(termSelect), timeout);
 			latest.setTerm(selector.getTerm().getId());
-			CourseSearchParser courseParse = new CourseSearchParser(pool.invoke(courseSelect), new LegacyDataModelPersister(latest));
+			CourseSearchParser courseParse = new CourseSearchParser(pool.invoke(courseSelect), timeout, new LegacyDataModelPersister(latest));
 			
 			pool.invoke(courseParse);
 			

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/banner/CourseParser.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/banner/CourseParser.java
@@ -66,9 +66,10 @@ public class CourseParser extends AbstractParser<Map<String, String>>{
 	 * from the main course search results page
 	 * 
 	 * @param document the course document
+	 * @param timeout the socket connection timeout for any created connections
 	 */
-	public CourseParser(Document document){
-		super(document);
+	public CourseParser(Document document, int timeout){
+		super(document, timeout);
 	}
 
 	/* (non-Javadoc)
@@ -111,8 +112,8 @@ public class CourseParser extends AbstractParser<Map<String, String>>{
 		String catalogEntryURL = catalogEntryElement.absUrl("href");
 		values.put("catalog", catalogEntryURL);
 		
-		parseCourseDetail(Jsoup.connect(sectionDetailURL).get(), values);
-		parseCatalogEntry(Jsoup.connect(catalogEntryURL).get(), values);
+		parseCourseDetail(Jsoup.connect(sectionDetailURL).timeout(this.getTimeout()).get(), values);
+		parseCatalogEntry(Jsoup.connect(catalogEntryURL).timeout(this.getTimeout()).get(), values);
 	
 		Elements meetingHeaderElements = document.select("table.datadisplaytable:has(caption:containsOwn(Scheduled Meeting Times)) th.ddheader");
 		Elements meetingRowElements = document.select("table.datadisplaytable:has(caption:containsOwn(Scheduled Meeting Times)) tr:has(td.dddefault)");

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/banner/CourseSearchParser.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/banner/CourseSearchParser.java
@@ -60,10 +60,14 @@ public class CourseSearchParser extends AbstractParser<Void> {
 	private CoursePersister persister;
 	
 	/**
-	 * @param document
+	 * Course Search results page parser for retrieving Course Data
+	 * 
+	 * @param document the document containing the course search results
+	 * @param timeout the socket connection timeout for the course search
+	 * @param CoursePersister the course persister callback which saves the data
 	 */
-	public CourseSearchParser(Document document, CoursePersister persister){
-		super(document);
+	public CourseSearchParser(Document document, int timeout, CoursePersister persister){
+		super(document, timeout);
 		
 		this.persister = persister;
 	}
@@ -88,7 +92,7 @@ public class CourseSearchParser extends AbstractParser<Void> {
 			sectionDocument.appendChild(section);
 			sectionDocument.appendChild(sectionDetail);
 			
-			CourseParser courseParser = new CourseParser(sectionDocument);
+			CourseParser courseParser = new CourseParser(sectionDocument, this.getTimeout());
 			courseParsers.add(courseParser);
 			courseParser.fork();
 		}

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/banner/CourseSelectionParser.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/banner/CourseSelectionParser.java
@@ -61,9 +61,12 @@ public class CourseSelectionParser extends FormParser {
 	/**
 	 * Create a new CourseSelectionParser based on the specified document,
 	 * which should contain a form from Banner for selecting course data.
+	 * 
+	 * @param document the document from which to parse course selections
+	 * @param timeout the socket connection timeout which should be used 
 	 */
-	public CourseSelectionParser(Document document) {
-		super(document);
+	public CourseSelectionParser(Document document, int timeout) {
+		super(document, timeout);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/io/devyse/scheduler/parse/jsoup/banner/TermSelectionParser.java
+++ b/src/main/java/io/devyse/scheduler/parse/jsoup/banner/TermSelectionParser.java
@@ -73,10 +73,11 @@ public class TermSelectionParser extends FormParser {
 	 * in the TermSelection form.
 	 * 
 	 * @param document the term selection document which contains the available terms
+	 * @param timeout the socket connection timeout to use during term selection
 	 * @param selector the term selection mechanism for deciding among available terms
 	 */
-	public TermSelectionParser(Document document, TermSelector selector) {
-		super(document);
+	public TermSelectionParser(Document document, int timeout, TermSelector selector) {
+		super(document, timeout);
 		
 		this.selector = selector;
 	}

--- a/src/main/resources/Readme.txt
+++ b/src/main/resources/Readme.txt
@@ -27,7 +27,9 @@ ChangeLog
 4.12.9
 	-Fixes issue #32, bug preventing course download due to high latency server responses (>30 seconds) by adding a socket connection timeout configuration
 	-Added UI option for configuring the socket timeout
-	-Increased default timeout from JRE default of 3s to 45s per statistical testing against jweb.kettering.edu   
+	-Increased default timeout from JRE default of 3s to 45s per statistical testing against jweb.kettering.edu
+	-Added better error transparency during course data retrieval tto better allow for the user to identify the problem
+	-Changed from console logging to a single, non-rolling, overwritten log file for better error reporting and ease of use   
 	
 4.12.8
 	-Fixes issue #29, bug preventing download of course data for Summer 2015 due to invalid credit value check

--- a/src/main/resources/Readme.txt
+++ b/src/main/resources/Readme.txt
@@ -1,5 +1,5 @@
 Course Scheduler
-Open Sourcescheduler-legacy-4.12.7-SNAPSHOT/
+Open Source
 
 Source is available on request via email to licensing@coursescheduler.io
 Redistribution in source and binary forms, with or without modification
@@ -24,6 +24,11 @@ in future releases.
  	This will allow you to uninstall, reinstall, or completely remove the Scheduler from your computer.
 
 ChangeLog
+4.12.9
+	-Fixes issue #32, bug preventing course download due to high latency server responses (>30 seconds) by adding a socket connection timeout configuration
+	-Added UI option for configuring the socket timeout
+	-Increased default timeout from JRE default of 3s to 45s per statistical testing against jweb.kettering.edu   
+	
 4.12.8
 	-Fixes issue #29, bug preventing download of course data for Summer 2015 due to invalid credit value check
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,18 +7,20 @@
 	<!-- Default configuration properties -->
 	<property name="DEFAULT_PATTERN" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" />
 
-	
-	<!-- Standard out console appender -->
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+
+	<!-- Application directory log file appender -->
+	<appender name="STDLOG" class="ch.qos.logback.core.FileAppender">
+		<append>false</append>
 		<encoder>
 			<pattern>${DEFAULT_PATTERN}</pattern>
 		</encoder>
+		<file>${user.home}/Scheduler/Logs/scheduler.log</file>
 	</appender>
 	
-
+	
 	<!-- Root logger -->
 	<root level="warn">
-		<appender-ref ref="STDOUT" />
+		<appender-ref ref="STDLOG" />
 	</root>
 
 	<!-- Keen IO SDK -->
@@ -38,7 +40,7 @@
 	<logger name="io.devyse" level="info"/>
 
 
-	<!-- ContextListener that ensures JUL logging is as efficient as possible by propogating log levels to JUL -->
+	<!-- ContextListener that ensures JUL logging is as efficient as possible by propagating log levels to JUL -->
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
 	


### PR DESCRIPTION
Fixes issue #32 - server latency / load can cause the client to have a socket timeout exception. 

Updated all the sockets to use a new timeout configuration, defaulted to 45s (compared to JRE default of 3s). 45s was selected based on statistic measurement of current server response times plus some margin for variability and other factors. Socket timeout is configurable in the Settings pane.

Increased error reporting transparency during course data retrieval to better identify errors. Changed logging from console to single file under application directory. 
